### PR TITLE
Change sort order and some other improvements

### DIFF
--- a/bck_mgmt.py
+++ b/bck_mgmt.py
@@ -105,7 +105,7 @@ for repo in backup_repo:
             logging.error(log)
             crit_str += log
         else:
-            weeks_in_weekly = list(datetime.date.fromtimestamp(f.stat().st_mtime).isocalendar()[1] for f in weekly_path.glob(repo['pattern']))
+            weeks_in_weekly = list(datetime.date.fromtimestamp(f.stat().st_mtime).strftime("%Y-%W") for f in weekly_path.glob(repo['pattern']))
             subdirs.append('weekly')
 
     if 'monthly' in repo.keys():
@@ -115,7 +115,7 @@ for repo in backup_repo:
             logging.error(log)
             crit_str += log
         else:
-            months_in_monthly = list(datetime.date.fromtimestamp(f.stat().st_mtime).month for f in monthly_path.glob(repo['pattern']))
+            months_in_monthly = list(datetime.date.fromtimestamp(f.stat().st_mtime).strftime("%Y-%m") for f in monthly_path.glob(repo['pattern']))
             subdirs.append('monthly')
 
     if 'yearly' in repo.keys():
@@ -125,7 +125,7 @@ for repo in backup_repo:
             logging.error(log)
             crit_str += log
         else:
-            years_in_yearly = list(datetime.date.fromtimestamp(f.stat().st_mtime).year for f in yearly_path.glob(repo['pattern']))
+            years_in_yearly = list(datetime.date.fromtimestamp(f.stat().st_mtime).strftime("%Y") for f in yearly_path.glob(repo['pattern']))
             subdirs.append('yearly')
 
     if crit_str:
@@ -145,9 +145,9 @@ for repo in backup_repo:
         current_file = file[1]
         current_file_mtime = datetime.datetime.fromtimestamp(file[0])
         current_file_size = file[2]
-        current_file_week = current_file_mtime.isocalendar()[1]
-        current_file_month = current_file_mtime.month
-        current_file_year = current_file_mtime.year
+        current_file_week = current_file_mtime.strftime("%Y-%W")
+        current_file_month = current_file_mtime.strftime("%Y-%m")
+        current_file_year = current_file_mtime.strftime("%Y")
 
         # clean up old files:
         if 'keep' in repo.keys() and ( len(sorted_file_list) - file_num ) > int(repo['keep']):

--- a/bck_mgmt.py
+++ b/bck_mgmt.py
@@ -39,7 +39,7 @@ def humanize_size(num, suffix='B'):
 
 def load_file_content(file, file_size):
     file_content = None
-    logging.debug("Loading content of file '{}' for comparison or compliance checking. ".format(previous_file))
+    logging.debug("Loading content of file '{}' for comparison or compliance checking. ".format(file))
     try:
         if file_size > MAX_FILE_SIZE_FOR_COMPLIANCE_CHECK:
             raise ValueError("File exceeds MAX_FILE_SIZE_FOR_COMPLIANCE_CHECK")


### PR DESCRIPTION
- Change the order in which the files in the base directory are processed to 'from old to new'. This way always the oldest file of a period is moved to the corresponding subdirectory. If the script was run daily, this was already the outcome.
- Always fill the yearly directory first, then monthly and weekly.
- Some improvements to the log output.